### PR TITLE
Issue #20 - Test publish a project and add a collaborator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ jobs:
           command: |
             echo $TEST_USERNAME > credentials.txt
             echo $TEST_PASSWORD >> credentials.txt
+            echo $COLLAB_USERNAME >> credentials.txt
+            echo $COLLAB_PASSWORD >> credentials.txt
 
       - run:
           name: Activate virtual env and run Gigantum

--- a/gigantum_tests/test_cloud_projects.py
+++ b/gigantum_tests/test_cloud_projects.py
@@ -28,6 +28,7 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
     testutils.remove_guide(driver)
     time.sleep(2)
     project_title = testutils.create_project_without_base(driver)
+
     # Python 3 minimal base
     testutils.add_py3_min_base(driver)
     wait = WebDriverWait(driver, 200)
@@ -127,6 +128,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     testutils.remove_guide(driver)
     time.sleep(2)
     project_title = testutils.create_project_without_base(driver)
+
     # Python 3 minimal base
     testutils.add_py3_min_base(driver)
     wait = WebDriverWait(driver, 200)
@@ -136,97 +138,67 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     publish_elts = testutils.PublishProjectElements(driver)
     publish_elts.publish_project_button.click()
     publish_elts.publish_confirm_button.click()
-    time.sleep(5)
+    time.sleep(2)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
 
     # Add collaborator
     logging.info("Adding a collaborator to private project")
     publish_elts.collaborators_button.click()
-    time.sleep(3)
+    time.sleep(2)
     credentials = open('credentials.txt').readlines()
     username2, password2 = credentials[2], credentials[3]
     publish_elts.collaborators_input.send_keys(username2)
     publish_elts.add_collaborators_button.click()
-    time.sleep(3)
+    time.sleep(2)
     publish_elts.close_collaborators_button.click()
-    logging.info("Logging out")
-    time.sleep(2)
-    driver.find_element_by_css_selector("#username").click()
-    time.sleep(2)
-    driver.find_element_by_css_selector("#logout").click()
-    time.sleep(3)
-    driver.quit()
+    testutils.log_out(driver)
 
     # Collaborator checks that the project is in the cloud tab and that the project imports successfully
-    logging.info("Switching to new driver for collaborator")
-    chrome_options = webdriver.ChromeOptions()
-    chrome_options.add_argument("--headless")
-    chrome_options.add_argument("--incognito")
-    driver2 = webdriver.Chrome(chrome_options=chrome_options)
-    driver2.implicitly_wait(5)
-    driver2.set_window_size(1440, 1000)
-    driver2.get("http://localhost:10000/projects/local#")
-    logging.info("Logging in")
-    auth0_elts = testutils.Auth0LoginElements(driver2)
-    auth0_elts.login_green_button.click()
+    logging.info("Logging in as a collaborator")
+    testutils.log_in(driver, user_index = 1)
     time.sleep(2)
-    auth0_elts.username_input.click()
-    auth0_elts.username_input.send_keys(username2)
-    auth0_elts.password_input.click()
-    auth0_elts.password_input.send_keys(password2)
-    driver2.find_element_by_css_selector(".auth0-lock-submit").click()
-    time.sleep(5)
-    testutils.remove_guide(driver2)
+    testutils.remove_guide(driver)
+    time.sleep(2)
     logging.info("Collaborator importing shared project")
-    driver2.find_element_by_css_selector(".Labbooks__nav-item--cloud").click()
-    time.sleep(2)
-    wait2 = WebDriverWait(driver2, 200)
-    wait2.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))
-    assert project_title in driver2.find_element_by_css_selector(".RemoteLabbooks__panel-title:first-child span span").text, "Expected shared project to in cloud tab"
-    driver2.find_element_by_css_selector(".RemoteLabbooks__icon--cloud-download").click()
-    wait2.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
-    assert project_title in driver2.find_element_by_css_selector(".TitleSection__namespace-title").text, "After import, expected shared project page"
-    logging.info("Logging out")
-    time.sleep(2)
-    driver2.find_element_by_css_selector("#username").click()
-    time.sleep(2)
-    driver2.find_element_by_css_selector("#logout").click()
-    time.sleep(3)
-    driver2.quit()
+    publish_elts.cloud_tab.click()
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))
+
+    # Test that shared cloud project is in cloud tab
+    cloud_tab_first_project_title_delete = driver.find_element_by_css_selector(
+        ".RemoteLabbooks__panel-title:first-child span span").text
+    assert cloud_tab_first_project_title_delete == project_title, "Expected shared cloud project in cloud tab"
+
+    publish_elts.download_cloud_project_button.click()
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
+
+    # Test that after import, the shared project opens to overview page
+    shared_project_title = driver.find_element_by_css_selector(".TitleSection__namespace-title").text
+    assert shared_project_title == project_title, "After import, expected shared project to open to overview page"
+
+    testutils.log_out(driver)
 
     # Owner deletes cloud project
-    logging.info("Switching to new driver for owner")
-    lines2 = open('credentials.txt').readlines()
-    username3, password3 = lines2[0], lines2[1]
-    driver3 = webdriver.Chrome(chrome_options=chrome_options)
-    driver3.implicitly_wait(5)
-    driver3.set_window_size(1440, 1000)
-    driver3.get("http://localhost:10000/projects/local#")
-    logging.info("Logging in")
-    auth0_elts = testutils.Auth0LoginElements(driver3)
-    auth0_elts.login_green_button.click()
+    testutils.log_in(driver)
     time.sleep(2)
-    auth0_elts.username_input.click()
-    auth0_elts.username_input.send_keys(username3)
-    auth0_elts.password_input.click()
-    auth0_elts.password_input.send_keys(password3)
-    time.sleep(10)
-    testutils.remove_guide(driver3)
+    testutils.remove_guide(driver)
+    time.sleep(2)
     logging.info("Owner deleting shared project")
-    driver3.find_element_by_css_selector(".SideBar__icon--labbooks-selected").click()
-    driver3.find_element_by_css_selector(".Labbooks__nav-item--cloud").click()
+    publish_elts.cloud_tab.click()
     time.sleep(2)
-    wait3 = selenium.webdriver.support.ui.WebDriverWait(driver3, 200)
-    wait3.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))
-    driver3.find_element_by_css_selector(".RemoteLabbooks__icon--delete").click()
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))
+    publish_elts.delete_project_button.click()
     time.sleep(2)
-    driver3.find_element_by_css_selector("#deleteInput").send_keys(project_title)
+    publish_elts.delete_project_input.send_keys(project_title)
     time.sleep(2)
-    driver3.find_element_by_css_selector(".ButtonLoader").click()
+    publish_elts.delete_confirm_button.click()
     time.sleep(5)
-    git_command2 = Popen(['git', 'remote', 'get-url', 'origin'], cwd=project_path, stdout=PIPE, stderr=PIPE)
-    del_stderr = git_command2.stderr.readline().decode('utf-8').strip()
-    assert "fatal" in del_stderr, "Expected project to be deleted from remote"
+    project_path = os.path.join(os.environ['GIGANTUM_HOME'], username, username,
+                                'labbooks', project_title)
+    git_get_remote_command_1 = Popen(['git', 'remote', 'get-url', 'origin'],
+                                     cwd=project_path, stdout=PIPE, stderr=PIPE)
+    del_stderr = git_get_remote_command_1.stderr.readline().decode('utf-8').strip()
+
+    assert "fatal" in del_stderr, f"Expected to not see a remote set for project, but got {del_stderr}"
 
 
 

--- a/gigantum_tests/test_cloud_projects.py
+++ b/gigantum_tests/test_cloud_projects.py
@@ -35,7 +35,7 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
 
     # Publish project
-    logging.info(f"Publishing private {project_title}")
+    logging.info(f"Publishing private project {project_title}")
     publish_elts = testutils.PublishProjectElements(driver)
     publish_elts.publish_project_button.click()
     publish_elts.publish_confirm_button.click()
@@ -58,7 +58,8 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
                                      cwd=project_path, stdout=PIPE, stderr=PIPE)
     pub_stdout = git_get_remote_command_1.stdout.readline().decode('utf-8').strip()
 
-    assert "https://" in pub_stdout, f"Expected to see a remote set for {project_title}, but got {pub_stdout}"
+    assert "https://" in pub_stdout, f"Expected to see a remote set for private project " \
+                                     f"{project_title}, but got {pub_stdout}"
 
     publish_elts.local_tab.click()
     driver.find_element_by_css_selector(f"a[href='/projects/{username}/{project_title}']").click()
@@ -143,7 +144,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
 
     # Add collaborator
-    logging.info(f"Adding a collaborator to private {project_title}")
+    logging.info(f"Adding a collaborator to private project {project_title}")
     publish_elts.collaborators_button.click()
     time.sleep(2)
     username2 = testutils.load_credentials(user_index=1)
@@ -170,7 +171,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     cloud_tab_first_project_title_delete = driver.find_element_by_css_selector(
         ".RemoteLabbooks__panel-title:first-child span span").text
     assert cloud_tab_first_project_title_delete == project_title, \
-        f"Expected shared cloud {project_title} in cloud tab"
+        f"Expected shared cloud project {project_title} in cloud tab"
 
     publish_elts.import_first_cloud_project_button.click()
     time.sleep(2)
@@ -179,7 +180,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     # Test that after import, the shared project opens to overview page
     shared_project_title = driver.find_element_by_css_selector(".TitleSection__namespace-title").text
     assert project_title in shared_project_title, \
-        f"After import, expected shared {project_title} to open to overview page"
+        f"After import, expected shared project {project_title} to open to overview page"
 
     testutils.log_out(driver)
 
@@ -191,7 +192,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     except:
         pass
     time.sleep(2)
-    logging.info(f"Owner deleting shared {project_title} from cloud")
+    logging.info(f"{username} deleting shared {project_title} from cloud")
     publish_elts.cloud_tab.click()
     time.sleep(2)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))

--- a/gigantum_tests/test_cloud_projects.py
+++ b/gigantum_tests/test_cloud_projects.py
@@ -34,7 +34,7 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
 
     # Publish project
-    logging.info("Publishing project")
+    logging.info("Publishing private project")
     publish_elts = testutils.PublishProjectElements(driver)
     publish_elts.publish_project_button.click()
     publish_elts.publish_confirm_button.click()
@@ -112,3 +112,121 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
     del_stderr = git_get_remote_command_2.stderr.readline().decode('utf-8').strip()
 
     assert "fatal" in del_stderr, f"Expected to not see a remote set for project, but got {del_stderr}"
+
+
+def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
+    """
+        Test that a project in Gigantum can be published, shared with a collaborator, and imported by the collaborator.
+
+        Args:
+            driver
+    """
+    # Project set up
+    username = testutils.log_in(driver)
+    time.sleep(2)
+    testutils.remove_guide(driver)
+    time.sleep(2)
+    project_title = testutils.create_project_without_base(driver)
+    # Python 3 minimal base
+    testutils.add_py3_min_base(driver)
+    wait = WebDriverWait(driver, 200)
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
+
+    # Publish project
+    publish_elts = testutils.PublishProjectElements(driver)
+    publish_elts.publish_project_button.click()
+    publish_elts.publish_confirm_button.click()
+    time.sleep(5)
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
+
+    # Add collaborator
+    logging.info("Adding a collaborator to private project")
+    publish_elts.collaborators_button.click()
+    time.sleep(3)
+    credentials = open('credentials.txt').readlines()
+    username2, password2 = credentials[2], credentials[3]
+    publish_elts.collaborators_input.send_keys(username2)
+    publish_elts.add_collaborators_button.click()
+    time.sleep(3)
+    publish_elts.close_collaborators_button.click()
+    logging.info("Logging out")
+    time.sleep(2)
+    driver.find_element_by_css_selector("#username").click()
+    time.sleep(2)
+    driver.find_element_by_css_selector("#logout").click()
+    time.sleep(3)
+    driver.quit()
+
+    # Collaborator checks that the project is in the cloud tab and that the project imports successfully
+    logging.info("Switching to new driver for collaborator")
+    chrome_options = webdriver.ChromeOptions()
+    chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--incognito")
+    driver2 = webdriver.Chrome(chrome_options=chrome_options)
+    driver2.implicitly_wait(5)
+    driver2.set_window_size(1440, 1000)
+    driver2.get("http://localhost:10000/projects/local#")
+    logging.info("Logging in")
+    auth0_elts = testutils.Auth0LoginElements(driver2)
+    auth0_elts.login_green_button.click()
+    time.sleep(2)
+    auth0_elts.username_input.click()
+    auth0_elts.username_input.send_keys(username2)
+    auth0_elts.password_input.click()
+    auth0_elts.password_input.send_keys(password2)
+    driver2.find_element_by_css_selector(".auth0-lock-submit").click()
+    time.sleep(5)
+    testutils.remove_guide(driver2)
+    logging.info("Collaborator importing shared project")
+    driver2.find_element_by_css_selector(".Labbooks__nav-item--cloud").click()
+    time.sleep(2)
+    wait2 = WebDriverWait(driver2, 200)
+    wait2.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))
+    assert project_title in driver2.find_element_by_css_selector(".RemoteLabbooks__panel-title:first-child span span").text, "Expected shared project to in cloud tab"
+    driver2.find_element_by_css_selector(".RemoteLabbooks__icon--cloud-download").click()
+    wait2.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
+    assert project_title in driver2.find_element_by_css_selector(".TitleSection__namespace-title").text, "After import, expected shared project page"
+    logging.info("Logging out")
+    time.sleep(2)
+    driver2.find_element_by_css_selector("#username").click()
+    time.sleep(2)
+    driver2.find_element_by_css_selector("#logout").click()
+    time.sleep(3)
+    driver2.quit()
+
+    # Owner deletes cloud project
+    logging.info("Switching to new driver for owner")
+    lines2 = open('credentials.txt').readlines()
+    username3, password3 = lines2[0], lines2[1]
+    driver3 = webdriver.Chrome(chrome_options=chrome_options)
+    driver3.implicitly_wait(5)
+    driver3.set_window_size(1440, 1000)
+    driver3.get("http://localhost:10000/projects/local#")
+    logging.info("Logging in")
+    auth0_elts = testutils.Auth0LoginElements(driver3)
+    auth0_elts.login_green_button.click()
+    time.sleep(2)
+    auth0_elts.username_input.click()
+    auth0_elts.username_input.send_keys(username3)
+    auth0_elts.password_input.click()
+    auth0_elts.password_input.send_keys(password3)
+    time.sleep(10)
+    testutils.remove_guide(driver3)
+    logging.info("Owner deleting shared project")
+    driver3.find_element_by_css_selector(".SideBar__icon--labbooks-selected").click()
+    driver3.find_element_by_css_selector(".Labbooks__nav-item--cloud").click()
+    time.sleep(2)
+    wait3 = selenium.webdriver.support.ui.WebDriverWait(driver3, 200)
+    wait3.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))
+    driver3.find_element_by_css_selector(".RemoteLabbooks__icon--delete").click()
+    time.sleep(2)
+    driver3.find_element_by_css_selector("#deleteInput").send_keys(project_title)
+    time.sleep(2)
+    driver3.find_element_by_css_selector(".ButtonLoader").click()
+    time.sleep(5)
+    git_command2 = Popen(['git', 'remote', 'get-url', 'origin'], cwd=project_path, stdout=PIPE, stderr=PIPE)
+    del_stderr = git_command2.stderr.readline().decode('utf-8').strip()
+    assert "fatal" in del_stderr, "Expected project to be deleted from remote"
+
+
+

--- a/gigantum_tests/test_cloud_projects.py
+++ b/gigantum_tests/test_cloud_projects.py
@@ -26,7 +26,7 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
     username = testutils.log_in(driver)
     time.sleep(2)
     testutils.remove_guide(driver)
-    time.sleep(2)
+    time.sleep(3)
     project_title = testutils.create_project_without_base(driver)
 
     # Python 3 minimal base
@@ -85,6 +85,7 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))
 
     # Delete cloud project
+    logging.info(f"Deleting {project_title} from cloud")
     publish_elts.delete_project_button.click()
     time.sleep(2)
     publish_elts.delete_project_input.send_keys(project_title)
@@ -145,8 +146,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     logging.info("Adding a collaborator to private project")
     publish_elts.collaborators_button.click()
     time.sleep(2)
-    credentials = open('credentials.txt').readlines()
-    username2, password2 = credentials[2], credentials[3]
+    username2 = testutils.load_credentials(user_index=1)
     publish_elts.collaborators_input.send_keys(username2)
     publish_elts.add_collaborators_button.click()
     time.sleep(2)
@@ -155,12 +155,15 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
 
     # Collaborator checks that the project is in the cloud tab and that the project imports successfully
     logging.info("Logging in as a collaborator")
-    testutils.log_in(driver, user_index = 1)
+    testutils.log_in(driver, user_index=1)
     time.sleep(2)
-    testutils.remove_guide(driver)
+    try:
+        testutils.remove_guide(driver)
+    except:
+        pass
     time.sleep(2)
-    logging.info("Collaborator importing shared project")
     publish_elts.cloud_tab.click()
+    time.sleep(2)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))
 
     # Test that shared cloud project is in cloud tab
@@ -169,20 +172,24 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     assert cloud_tab_first_project_title_delete == project_title, "Expected shared cloud project in cloud tab"
 
     publish_elts.download_cloud_project_button.click()
+    time.sleep(2)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
 
     # Test that after import, the shared project opens to overview page
     shared_project_title = driver.find_element_by_css_selector(".TitleSection__namespace-title").text
-    assert shared_project_title == project_title, "After import, expected shared project to open to overview page"
+    assert project_title in shared_project_title, "After import, expected shared project to open to overview page"
 
     testutils.log_out(driver)
 
     # Owner deletes cloud project
     testutils.log_in(driver)
     time.sleep(2)
-    testutils.remove_guide(driver)
+    try:
+        testutils.remove_guide(driver)
+    except:
+        pass
     time.sleep(2)
-    logging.info("Owner deleting shared project")
+    logging.info("Owner deleting shared project from cloud")
     publish_elts.cloud_tab.click()
     time.sleep(2)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))

--- a/gigantum_tests/test_cloud_projects.py
+++ b/gigantum_tests/test_cloud_projects.py
@@ -35,7 +35,7 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
 
     # Publish project
-    logging.info("Publishing private project")
+    logging.info(f"Publishing private {project_title}")
     publish_elts = testutils.PublishProjectElements(driver)
     publish_elts.publish_project_button.click()
     publish_elts.publish_confirm_button.click()
@@ -50,7 +50,7 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
     cloud_tab_first_project_title_publish = driver.find_element_by_css_selector(
         ".RemoteLabbooks__panel-title:first-child span span").text
     assert cloud_tab_first_project_title_publish == project_title, \
-        "Expected project to be the first project in the cloud tab"
+        f"Expected {project_title} to be the first project in the cloud tab"
 
     project_path = os.path.join(os.environ['GIGANTUM_HOME'], username, username,
                                 'labbooks', project_title)
@@ -58,7 +58,7 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
                                      cwd=project_path, stdout=PIPE, stderr=PIPE)
     pub_stdout = git_get_remote_command_1.stdout.readline().decode('utf-8').strip()
 
-    assert "https://" in pub_stdout, f"Expected to see a remote set for project, but got {pub_stdout}"
+    assert "https://" in pub_stdout, f"Expected to see a remote set for {project_title}, but got {pub_stdout}"
 
     publish_elts.local_tab.click()
     driver.find_element_by_css_selector(f"a[href='/projects/{username}/{project_title}']").click()
@@ -97,7 +97,7 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
     cloud_tab_first_project_title_delete = driver.find_element_by_css_selector(
         ".RemoteLabbooks__panel-title:first-child span span").text
     assert cloud_tab_first_project_title_delete != project_title, \
-        "Expected project to not be the first project in the cloud tab"
+        f"Expected {project_title} to not be the first project in the cloud tab"
 
     publish_elts.local_tab.click()
     time.sleep(2)
@@ -107,13 +107,13 @@ def test_publish_sync_delete_project(driver: selenium.webdriver, *args, **kwargs
     local_tab_first_project_title = driver.find_element_by_css_selector(
         ".LocalLabbooks__panel-title:first-child span span").text
     assert local_tab_first_project_title == project_title, \
-        "Expected project to be the first project in the local tab"
+        f"Expected {project_title} to be the first project in the local tab"
 
     git_get_remote_command_2 = Popen(['git', 'remote', 'get-url', 'origin'],
                                      cwd=project_path, stdout=PIPE, stderr=PIPE)
     del_stderr = git_get_remote_command_2.stderr.readline().decode('utf-8').strip()
 
-    assert "fatal" in del_stderr, f"Expected to not see a remote set for project, but got {del_stderr}"
+    assert "fatal" in del_stderr, f"Expected to not see a remote set for {project_title}, but got {del_stderr}"
 
 
 def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
@@ -143,7 +143,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
 
     # Add collaborator
-    logging.info("Adding a collaborator to private project")
+    logging.info(f"Adding a collaborator to private {project_title}")
     publish_elts.collaborators_button.click()
     time.sleep(2)
     username2 = testutils.load_credentials(user_index=1)
@@ -169,7 +169,8 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     # Test that shared cloud project is in cloud tab
     cloud_tab_first_project_title_delete = driver.find_element_by_css_selector(
         ".RemoteLabbooks__panel-title:first-child span span").text
-    assert cloud_tab_first_project_title_delete == project_title, "Expected shared cloud project in cloud tab"
+    assert cloud_tab_first_project_title_delete == project_title, \
+        f"Expected shared cloud {project_title} in cloud tab"
 
     publish_elts.download_cloud_project_button.click()
     time.sleep(2)
@@ -177,7 +178,8 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
 
     # Test that after import, the shared project opens to overview page
     shared_project_title = driver.find_element_by_css_selector(".TitleSection__namespace-title").text
-    assert project_title in shared_project_title, "After import, expected shared project to open to overview page"
+    assert project_title in shared_project_title, \
+        f"After import, expected shared {project_title} to open to overview page"
 
     testutils.log_out(driver)
 
@@ -189,7 +191,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     except:
         pass
     time.sleep(2)
-    logging.info("Owner deleting shared project from cloud")
+    logging.info(f"Owner deleting shared {project_title} from cloud")
     publish_elts.cloud_tab.click()
     time.sleep(2)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".RemoteLabbooks__panel-title")))
@@ -205,7 +207,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
                                      cwd=project_path, stdout=PIPE, stderr=PIPE)
     del_stderr = git_get_remote_command_1.stderr.readline().decode('utf-8').strip()
 
-    assert "fatal" in del_stderr, f"Expected to not see a remote set for project, but got {del_stderr}"
+    assert "fatal" in del_stderr, f"Expected to not see a remote set for {project_title}, but got {del_stderr}"
 
 
 

--- a/gigantum_tests/test_cloud_projects.py
+++ b/gigantum_tests/test_cloud_projects.py
@@ -154,7 +154,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     testutils.log_out(driver)
 
     # Collaborator checks that the project is in the cloud tab and that the project imports successfully
-    logging.info("Logging in as a collaborator")
+    logging.info(f"Logging in as {username2[0].rstrip()}")
     testutils.log_in(driver, user_index=1)
     time.sleep(2)
     try:
@@ -172,7 +172,7 @@ def test_publish_collaborator(driver: selenium.webdriver, *args, ** kwargs):
     assert cloud_tab_first_project_title_delete == project_title, \
         f"Expected shared cloud {project_title} in cloud tab"
 
-    publish_elts.download_cloud_project_button.click()
+    publish_elts.import_first_cloud_project_button.click()
     time.sleep(2)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
 

--- a/testutils/actions.py
+++ b/testutils/actions.py
@@ -21,7 +21,7 @@ def log_in(driver: selenium.webdriver, user_index: int = 0) -> str:
 
     Args:
         driver
-        user_index:
+        user_index: an offset into credentials.txt
 
     Returns:
         Username of user just logged in

--- a/testutils/actions.py
+++ b/testutils/actions.py
@@ -27,7 +27,6 @@ def log_in(driver: selenium.webdriver, user_index: int = 0) -> str:
         Username of user just logged in
     """
     driver.get("http://localhost:10000/projects/local#")
-    logging.info("Logging in")
     auth0_elts = elements.Auth0LoginElements(driver)
     auth0_elts.login_green_button.click()
     time.sleep(2)
@@ -39,6 +38,7 @@ def log_in(driver: selenium.webdriver, user_index: int = 0) -> str:
         pass
     time.sleep(2)
     username, password = testutils.load_credentials(user_index=user_index)
+    logging.info(f"Logging in as {username}")
     auth0_elts.username_input.click()
     auth0_elts.username_input.send_keys(username)
     auth0_elts.password_input.click()

--- a/testutils/actions.py
+++ b/testutils/actions.py
@@ -15,12 +15,13 @@ from testutils import testutils
 
 
 # create project
-def log_in(driver: selenium.webdriver) -> str:
+def log_in(driver: selenium.webdriver, user_index: int = 0) -> str:
     """
     Log in to Gigantum.
 
     Args:
         driver
+        user_index:
 
     Returns:
         Username of user just logged in
@@ -30,7 +31,7 @@ def log_in(driver: selenium.webdriver) -> str:
     auth0_elts = elements.Auth0LoginElements(driver)
     auth0_elts.login_green_button.click()
     time.sleep(2)
-    username,password = testutils.load_credentials()
+    username, password = testutils.load_credentials(user_index)
     auth0_elts.username_input.click()
     auth0_elts.username_input.send_keys(username)
     auth0_elts.password_input.click()
@@ -296,7 +297,6 @@ def publish_dataset(driver: selenium.webdriver):
 
     Args:
         driver
-
     """
     logging.info("Publish dataset to cloud")
     dataset_elts = elements.AddDatasetElements(driver)
@@ -310,4 +310,17 @@ def publish_dataset(driver: selenium.webdriver):
     wait.until(EC.invisibility_of_element_located((By.CSS_SELECTOR, ".VisibilityModal__buttons")))
 
 
+def log_out(driver: selenium.webdriver):
+    """
+    Log out of Gigantum.
 
+    Args:
+     driver
+    """
+    logging.info("Logging out")
+    time.sleep(2)
+    side_bar_elts = elements.SideBarElements(driver)
+    side_bar_elts.username_button.click()
+    time.sleep(2)
+    side_bar_elts.logout_button.click()
+    time.sleep(2)

--- a/testutils/actions.py
+++ b/testutils/actions.py
@@ -31,6 +31,13 @@ def log_in(driver: selenium.webdriver, user_index: int = 0) -> str:
     auth0_elts = elements.Auth0LoginElements(driver)
     auth0_elts.login_green_button.click()
     time.sleep(2)
+    try:
+        if auth0_elts.auth0_lock_button:
+            logging.info("Clicking 'Not your account?'")
+            auth0_elts.not_your_account_button.click()
+    except:
+        pass
+    time.sleep(2)
     username, password = testutils.load_credentials(user_index=user_index)
     auth0_elts.username_input.click()
     auth0_elts.username_input.send_keys(username)

--- a/testutils/actions.py
+++ b/testutils/actions.py
@@ -31,7 +31,7 @@ def log_in(driver: selenium.webdriver, user_index: int = 0) -> str:
     auth0_elts = elements.Auth0LoginElements(driver)
     auth0_elts.login_green_button.click()
     time.sleep(2)
-    username, password = testutils.load_credentials(user_index)
+    username, password = testutils.load_credentials(user_index=user_index)
     auth0_elts.username_input.click()
     auth0_elts.username_input.send_keys(username)
     auth0_elts.password_input.click()

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -11,6 +11,14 @@ class Auth0LoginElements(UiElement):
         return self.driver.find_element_by_css_selector(".Login__button")
 
     @property
+    def auth0_lock_button(self):
+        return self.driver.find_element_by_css_selector(".auth0-lock-social-button")
+
+    @property
+    def not_your_account_button(self):
+        return self.driver.find_element_by_css_selector(".auth0-lock-alternative-link")
+
+    @property
     def username_input(self):
         return self.driver.find_element_by_css_selector(".auth0-lock-input[name = username]")
 

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -300,7 +300,7 @@ class PublishProjectElements(UiElement):
         return self.driver.find_element_by_css_selector(".Modal__close")
 
     @property
-    def download_cloud_project_button(self):
+    def import_first_cloud_project_button(self):
         return self.driver.find_element_by_css_selector(".RemoteLabbooks__icon--cloud-download")
 
 

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -173,6 +173,14 @@ class SideBarElements(UiElement):
     def projects_icon(self):
         return self.driver.find_element_by_css_selector(".SideBar__nav-item--labbooks")
 
+    @property
+    def username_button(self):
+        return self.driver.find_element_by_css_selector("#username")
+
+    @property
+    def logout_button(self):
+        return self.driver.find_element_by_css_selector("#logout")
+
 
 class AddDatasetElements(UiElement):
     @property
@@ -201,7 +209,7 @@ class AddDatasetElements(UiElement):
 
     @property
     def create_dataset_button(self):
-        return self.driver.find_element_by_css_selector(".ButtonLoader ")
+        return self.driver.find_element_by_css_selector(".ButtonLoader")
 
     @property
     def publish_dataset_button(self):
@@ -283,10 +291,15 @@ class PublishProjectElements(UiElement):
     def close_collaborators_button(self):
         return self.driver.find_element_by_css_selector(".Modal__close")
 
+    @property
+    def download_cloud_project_button(self):
+        return self.driver.find_element_by_css_selector(".RemoteLabbooks__icon--cloud-download")
+
 
 class InputDataElements(UiElement):
     @property
     def input_data_tab(self):
         return self.driver.find_element_by_css_selector("#inputData")
+
 
 

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -267,8 +267,26 @@ class PublishProjectElements(UiElement):
     def delete_confirm_button(self):
         return self.driver.find_element_by_css_selector(".ButtonLoader")
 
+    @property
+    def collaborators_button(self):
+        return self.driver.find_element_by_css_selector(".Collaborators__btn")
+
+    @property
+    def collaborators_input(self):
+        return self.driver.find_element_by_css_selector(".CollaboratorsModal__input--collaborators")
+
+    @property
+    def add_collaborators_button(self):
+        return self.driver.find_element_by_css_selector(".CollaboratorsModal__btn--add")
+
+    @property
+    def close_collaborators_button(self):
+        return self.driver.find_element_by_css_selector(".Modal__close")
+
 
 class InputDataElements(UiElement):
     @property
     def input_data_tab(self):
         return self.driver.find_element_by_css_selector("#inputData")
+
+

--- a/testutils/testutils.py
+++ b/testutils/testutils.py
@@ -46,14 +46,14 @@ def unique_project_description():
     return ''.join([str(uuid.uuid4())[:6] for num in range(30)])
 
 
-def load_credentials(path: str = 'credentials.txt'):
+def load_credentials(path: str = 'credentials.txt', user_index: int = 0):
     """ Return tuple of username and password """
     assert os.path.exists(path), f"Specificy login credentials in {path}"
     with open(path) as cfile:
         lines = cfile.readlines()
         assert len(lines) >= 2, f"Must have line for username and password in {path}"
     # return username (first line) and password (second line)
-    return lines[0], lines[1]
+    return lines[2 * user_index], lines[(2 * user_index) + 1]
 
 
 def valid_custom_docker_instruction():

--- a/testutils/testutils.py
+++ b/testutils/testutils.py
@@ -16,13 +16,16 @@ from selenium.webdriver.chrome.options import Options
 
 def load_chrome_driver():
     """ Return Chrome webdriver """
-    return webdriver.Chrome()
+    options = Options()
+    options.add_argument("--incognito")
+    return webdriver.Chrome(options=options)
 
 
 def load_chrome_driver_headless():
     """ Return headless Chrome webdriver """
     options = Options()
     options.add_argument("--headless")
+    options.add_argument("--incognito")
     return webdriver.Chrome(options=options)
 
 


### PR DESCRIPTION
## Pull Request for Issue #20 

**Description of Changes**
Created a test that...
Creates a project, publishes the project, and adds a collaborator with read only permissions
Collaborator logs in and checks that the project is in the cloud tab and that the project can be imported successfully
Owner logs in and deletes the cloud project
By having the owner delete the cloud project, the collaborator can take on different permissions

**Exit Criteria**
Tested on visible Chrome and headless Chrome
