### PR TITLE
Issue #42 - utility method to drop file in file browser

### DIFF
--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -21,8 +21,8 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
 
     # Navigate to code
     logging.info("Navigating to Code")
-    code_elts = testutils.CodeElements(driver)
-    code_elts.code_tab.click()
+    project_file_browser_elts = testutils.ProjectFileBrowserElements(driver)
+    project_file_browser_elts.code_tab.click()
     time.sleep(2)
     logging.info("Dragging and dropping file into code")
     testutils.file_drag_drop(driver)
@@ -33,8 +33,7 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
 
     # Navigate to input data
     logging.info("Navigating to Input Data")
-    input_data_elts = testutils.InputDataElements(driver)
-    input_data_elts.input_data_tab.click()
+    project_file_browser_elts.input_data_tab.click()
     logging.info("Dragging and dropping file into Input Data")
     testutils.file_drag_drop(driver)
     time.sleep(3)

--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -21,7 +21,7 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
     # Navigate to code
     logging.info("Navigating to Code")
     project_file_browser_elts = testutils.ProjectFileBrowserElements(driver)
-    project_file_browser_elts.code_tab.click()
+    project_file_browser_elts.code_tab.wait().click()
     time.sleep(2)
     logging.info("Dragging and dropping file into code")
     testutils.file_drag_drop(driver)
@@ -32,7 +32,7 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
 
     # Navigate to input data
     logging.info("Navigating to Input Data")
-    project_file_browser_elts.input_data_tab.click()
+    project_file_browser_elts.input_data_tab.wait().click()
     logging.info("Dragging and dropping file into Input Data")
     testutils.file_drag_drop(driver)
     time.sleep(3)

--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -78,7 +78,7 @@ def test_file_drag_drop_dataset_file_browser(driver: selenium.webdriver, *args, 
     logging.info("Navigating to Data")
     driver.find_element_by_css_selector("#data").click()
     logging.info("Dragging and dropping file into Data")
-    testutils.file_drag_drop(driver)
+    testutils.file_drag_drop(driver, project=False)
     time.sleep(3)
 
     data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text

--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -41,7 +41,7 @@ def test_project_file_browser(driver: selenium.webdriver, *args, **kwargs):
     assert input_data_first_file_title == 'sample-upload.txt', \
         "Expected sample-upload.txt to be the first file in Input Data"
 
-    # TODO - upload file to Output Data
+    # TODO - upload file to Output Data, need to deal with untracked directory
 
 
 def test_dataset_file_browser(driver: selenium.webdriver, *args, **kwargs):

--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -1,0 +1,87 @@
+import logging
+import time
+
+import selenium
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+import testutils
+
+
+def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, **kwargs):
+    """
+    Test that a file can be dragged and dropped into code, input data,
+    and output data in a project.
+
+    Args:
+        driver
+    """
+    # Project set up
+    testutils.log_in(driver)
+    time.sleep(2)
+    testutils.remove_guide(driver)
+    time.sleep(2)
+    testutils.create_project_without_base(driver)
+    time.sleep(2)
+    testutils.add_py3_min_base(driver)
+    wait = WebDriverWait(driver, 200)
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex > .Stopped")))
+    # Navigate to code
+    logging.info("Navigating to Code")
+    driver.find_element_by_css_selector("#code").click()
+    time.sleep(2)
+    logging.info("Dragging and dropping file into code")
+    testutils.file_drag_drop(driver)
+    time.sleep(3)
+
+    code_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
+    assert code_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be first file in Code"
+
+    # Navigate to input data
+    logging.info("Navigating to Input Data")
+    driver.find_element_by_css_selector("#inputData").click()
+    logging.info("Dragging and dropping file into Input Data")
+    testutils.file_drag_drop(driver)
+    time.sleep(3)
+
+    input_data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
+    assert input_data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be first file " \
+                                                               "in Input Data"
+
+    # Navigate to output data
+    logging.info("Navigating to Output Data")
+    driver.find_element_by_css_selector("#outputData").click()
+    logging.info("Dragging and dropping file into Output Data")
+    testutils.file_drag_drop(driver)
+    time.sleep(3)
+
+    output_data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
+    assert output_data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be first file " \
+                                                                "in Output Data"
+
+
+def test_file_drag_drop_dataset_file_browser(driver: selenium.webdriver, *args, **kwargs):
+    """
+    Test that a file can be dragged and dropped into data in a dataset.
+
+    Args:
+        driver
+    """
+    # Dataset set up
+    testutils.log_in(driver)
+    time.sleep(2)
+    testutils.remove_guide(driver)
+    time.sleep(2)
+    testutils.create_dataset(driver)
+    # Navigate to data
+    logging.info("Navigating to Data")
+    driver.find_element_by_css_selector("#data").click()
+    logging.info("Dragging and dropping file into Data")
+    testutils.file_drag_drop(driver)
+    time.sleep(3)
+
+    data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
+    assert data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be first file " \
+                                                         "in Data"
+

--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -18,6 +18,7 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
     # Project set up
     r = testutils.prep_py3_minimal_base(driver)
     username, project_title = r.username, r.project_name
+
     # Navigate to code
     logging.info("Navigating to Code")
     code_elts = testutils.CodeElements(driver)
@@ -42,17 +43,7 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
     assert input_data_first_file_title == 'sample-upload.txt', \
         "Expected sample-upload.txt to be the first file in Input Data"
 
-    # Navigate to output data
-    logging.info("Navigating to Output Data")
-    output_data_elts = testutils.elements.OutputDataElements(driver)
-    output_data_elts.output_data_tab.click()
-    logging.info("Dragging and dropping file into Output Data")
-    testutils.file_drag_drop(driver)
-    time.sleep(3)
-
-    output_data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
-    assert output_data_first_file_title == 'sample-upload.txt', \
-        "Expected sample-upload.txt to be the first file in Output Data"
+    # TODO - upload file to Output Data
 
 
 def test_file_drag_drop_dataset_file_browser(driver: selenium.webdriver, *args, **kwargs):
@@ -73,7 +64,8 @@ def test_file_drag_drop_dataset_file_browser(driver: selenium.webdriver, *args, 
     dataset_elts = testutils.elements.AddDatasetElements(driver)
     dataset_elts.data_tab.click()
     logging.info("Dragging and dropping file into Data")
-    testutils.file_drag_drop(driver, project=False)
+    time.sleep(3)
+    testutils.file_drag_drop(driver)
     time.sleep(3)
 
     data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text

--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -3,8 +3,6 @@ import time
 
 import selenium
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 
 import testutils
 
@@ -18,18 +16,12 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
         driver
     """
     # Project set up
-    testutils.log_in(driver)
-    time.sleep(2)
-    testutils.remove_guide(driver)
-    time.sleep(2)
-    testutils.create_project_without_base(driver)
-    time.sleep(2)
-    testutils.add_py3_min_base(driver)
-    wait = WebDriverWait(driver, 200)
-    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
+    r = testutils.prep_py3_minimal_base(driver)
+    username, project_title = r.username, r.project_name
     # Navigate to code
     logging.info("Navigating to Code")
-    driver.find_element_by_css_selector("#code").click()
+    code_elts = testutils.CodeElements(driver)
+    code_elts.code_tab.click()
     time.sleep(2)
     logging.info("Dragging and dropping file into code")
     testutils.file_drag_drop(driver)
@@ -40,25 +32,27 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
 
     # Navigate to input data
     logging.info("Navigating to Input Data")
-    driver.find_element_by_css_selector("#inputData").click()
+    input_data_elts = testutils.InputDataElements(driver)
+    input_data_elts.input_data_tab.click()
     logging.info("Dragging and dropping file into Input Data")
     testutils.file_drag_drop(driver)
     time.sleep(3)
 
     input_data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
-    assert input_data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be the first file " \
-                                                               "in Input Data"
+    assert input_data_first_file_title == 'sample-upload.txt', \
+        "Expected sample-upload.txt to be the first file in Input Data"
 
     # Navigate to output data
     logging.info("Navigating to Output Data")
-    driver.find_element_by_css_selector("#outputData").click()
+    output_data_elts = testutils.elements.OutputDataElements(driver)
+    output_data_elts.output_data_tab.click()
     logging.info("Dragging and dropping file into Output Data")
     testutils.file_drag_drop(driver)
     time.sleep(3)
 
     output_data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
-    assert output_data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be the first file " \
-                                                                "in Output Data"
+    assert output_data_first_file_title == 'sample-upload.txt', \
+        "Expected sample-upload.txt to be the first file in Output Data"
 
 
 def test_file_drag_drop_dataset_file_browser(driver: selenium.webdriver, *args, **kwargs):
@@ -76,12 +70,13 @@ def test_file_drag_drop_dataset_file_browser(driver: selenium.webdriver, *args, 
     testutils.create_dataset(driver)
     # Navigate to data
     logging.info("Navigating to Data")
-    driver.find_element_by_css_selector("#data").click()
+    dataset_elts = testutils.elements.AddDatasetElements(driver)
+    dataset_elts.data_tab.click()
     logging.info("Dragging and dropping file into Data")
     testutils.file_drag_drop(driver, project=False)
     time.sleep(3)
 
     data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
-    assert data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be the first file " \
-                                                         "in Data"
+    assert data_first_file_title == 'sample-upload.txt', \
+        "Expected sample-upload.txt to be the first file in Data"
 

--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -7,7 +7,7 @@ from selenium.webdriver.common.by import By
 import testutils
 
 
-def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, **kwargs):
+def test_project_file_browser(driver: selenium.webdriver, *args, **kwargs):
     """
     Test that a file can be dragged and dropped into code, input data,
     and output data in a project.
@@ -44,7 +44,7 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
     # TODO - upload file to Output Data
 
 
-def test_file_drag_drop_dataset_file_browser(driver: selenium.webdriver, *args, **kwargs):
+def test_dataset_file_browser(driver: selenium.webdriver, *args, **kwargs):
     """
     Test that a file can be dragged and dropped into data in a dataset.
 

--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -18,7 +18,6 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
     # Project set up
     r = testutils.prep_py3_minimal_base(driver)
     username, project_title = r.username, r.project_name
-
     # Navigate to code
     logging.info("Navigating to Code")
     project_file_browser_elts = testutils.ProjectFileBrowserElements(driver)
@@ -54,14 +53,12 @@ def test_file_drag_drop_dataset_file_browser(driver: selenium.webdriver, *args, 
     """
     # Dataset set up
     testutils.log_in(driver)
-    time.sleep(2)
-    testutils.remove_guide(driver)
-    time.sleep(2)
-    testutils.create_dataset(driver)
+    testutils.GuideElements(driver).remove_guide()
+    dataset_elts = testutils.DatasetElements(driver)
+    dataset_elts.create_dataset(testutils.unique_dataset_name())
     # Navigate to data
     logging.info("Navigating to Data")
-    dataset_elts = testutils.elements.AddDatasetElements(driver)
-    dataset_elts.data_tab.click()
+    dataset_elts.data_tab.wait().click()
     logging.info("Dragging and dropping file into Data")
     time.sleep(3)
     testutils.file_drag_drop(driver)

--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -26,7 +26,7 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
     time.sleep(2)
     testutils.add_py3_min_base(driver)
     wait = WebDriverWait(driver, 200)
-    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex > .Stopped")))
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
     # Navigate to code
     logging.info("Navigating to Code")
     driver.find_element_by_css_selector("#code").click()
@@ -36,7 +36,7 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
     time.sleep(3)
 
     code_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
-    assert code_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be first file in Code"
+    assert code_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be the first file in Code"
 
     # Navigate to input data
     logging.info("Navigating to Input Data")
@@ -46,7 +46,7 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
     time.sleep(3)
 
     input_data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
-    assert input_data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be first file " \
+    assert input_data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be the first file " \
                                                                "in Input Data"
 
     # Navigate to output data
@@ -57,7 +57,7 @@ def test_file_drag_drop_project_file_browser(driver: selenium.webdriver, *args, 
     time.sleep(3)
 
     output_data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
-    assert output_data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be first file " \
+    assert output_data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be the first file " \
                                                                 "in Output Data"
 
 
@@ -82,6 +82,6 @@ def test_file_drag_drop_dataset_file_browser(driver: selenium.webdriver, *args, 
     time.sleep(3)
 
     data_first_file_title = driver.find_element_by_css_selector(".File__text div span").text
-    assert data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be first file " \
+    assert data_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be the first file " \
                                                          "in Data"
 

--- a/gigantum_tests/test_file_browser.py
+++ b/gigantum_tests/test_file_browser.py
@@ -19,11 +19,11 @@ def test_project_file_browser(driver: selenium.webdriver, *args, **kwargs):
     r = testutils.prep_py3_minimal_base(driver)
     username, project_title = r.username, r.project_name
     # Navigate to code
-    logging.info("Navigating to Code")
+    logging.info(f"Navigating to Code for project {project_title}")
     project_file_browser_elts = testutils.ProjectFileBrowserElements(driver)
     project_file_browser_elts.code_tab.wait().click()
     time.sleep(2)
-    logging.info("Dragging and dropping file into code")
+    logging.info(f"Dragging and dropping file into code for project {project_title}")
     testutils.file_drag_drop(driver)
     time.sleep(3)
 
@@ -31,9 +31,9 @@ def test_project_file_browser(driver: selenium.webdriver, *args, **kwargs):
     assert code_first_file_title == 'sample-upload.txt', "Expected sample-upload.txt to be the first file in Code"
 
     # Navigate to input data
-    logging.info("Navigating to Input Data")
+    logging.info(f"Navigating to Input Data for project {project_title}")
     project_file_browser_elts.input_data_tab.wait().click()
-    logging.info("Dragging and dropping file into Input Data")
+    logging.info(f"Dragging and dropping file into Input Data for project {project_title}")
     testutils.file_drag_drop(driver)
     time.sleep(3)
 
@@ -55,11 +55,10 @@ def test_dataset_file_browser(driver: selenium.webdriver, *args, **kwargs):
     testutils.log_in(driver)
     testutils.GuideElements(driver).remove_guide()
     dataset_elts = testutils.DatasetElements(driver)
-    dataset_elts.create_dataset(testutils.unique_dataset_name())
-    # Navigate to data
-    logging.info("Navigating to Data")
+    dataset_title = dataset_elts.create_dataset(testutils.unique_dataset_name())
+    logging.info(f"Navigating to Data for dataset {dataset_title}")
     dataset_elts.data_tab.wait().click()
-    logging.info("Dragging and dropping file into Data")
+    logging.info(f"Dragging and dropping file into Data for dataset {dataset_title}")
     time.sleep(3)
     testutils.file_drag_drop(driver)
     time.sleep(3)

--- a/testutils/actions.py
+++ b/testutils/actions.py
@@ -39,7 +39,7 @@ def prep_base(driver, base_button_check, skip_login=False):
     wait = selenium.webdriver.support.ui.WebDriverWait(driver, 200)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".flex>.Stopped")))
     # assert container status is stopped
-    container_elts = elements.PublishProjectElements(driver)
+    container_elts = elements.ProjectFileBrowserElements(driver)
     assert container_elts.container_status_stopped.wait().is_displayed(), "Expected stopped container"
 
     return ProjectPrepResponse(username=username, project_name=proj_name)

--- a/testutils/actions.py
+++ b/testutils/actions.py
@@ -311,7 +311,9 @@ def create_dataset(driver: selenium.webdriver) -> str:
     dataset_elts.dataset_description_input.click()
     dataset_elts.dataset_description_input.send_keys(testutils.unique_project_description())
     dataset_elts.dataset_continue_button.click()
+    time.sleep(2)
     dataset_elts.gigantum_cloud_button.click()
+    time.sleep(2)
     dataset_elts.create_dataset_button.click()
 
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".TitleSection")))

--- a/testutils/driverutil.py
+++ b/testutils/driverutil.py
@@ -96,6 +96,7 @@ class TestRunner:
                                 fail_message=str(e))
         finally:
             try:
+                driver.get("about:blank")
                 self._cleanup(driver)
             except Exception as e:
                 logging.error(f"Error cleaning up: {e}")

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -513,3 +513,4 @@ class ProjectFileBrowserElements(UiComponent):
         wait.until(EC.invisibility_of_element_located((By.CSS_SELECTOR, ".LinkModal__container")))
 
 
+

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -263,7 +263,7 @@ class DatasetElements(UiComponent):
 
     @property
     def data_tab(self):
-        return self.driver.find_element_by_css_selector("#data")
+        return CssElement(self.driver, '#data')
 
     @property
     def managed_cloud_card_selector(self):
@@ -273,7 +273,6 @@ class DatasetElements(UiComponent):
     @property
     def create_dataset_button(self):
         return CssElement(self.driver, '.ButtonLoader')
-
 
     @property
     def publish_dataset_button(self):
@@ -428,41 +427,6 @@ class PublishProjectElements(UiComponent):
     @property
     def import_first_cloud_project_button(self):
         return self.driver.find_element_by_css_selector(".Button__icon--cloud-download")
-
-
-class ProjectFileBrowserElements(UiElement):
-    @property
-    def code_tab(self):
-        return self.driver.find_element_by_css_selector("#code")
-
-    @property
-    def container_status_stopped(self):
-        return CssElement(self.driver, ".flex>.Stopped")
-
-    @property
-    def owner_title(self) -> Tuple[str, str]:
-        text = CssElement(self.driver, ".TitleSection__namespace-title").wait(5).text.split('/')
-        return text[0].strip(), text[1].strip()
-
-    def publish_project(self):
-        """
-            Publish a project to cloud. Then assert it is in list_remote_labbooks
-            """
-        owner, title = self.owner_title
-        logging.info(f"Publishing project {owner}/{title}...")
-        self.publish_project_button.wait().click()
-        self.publish_confirm_button.wait().click()
-        logging.info("Waiting for container status to be stopped.")
-        self.container_status_stopped.wait(20)
-        time.sleep(4)
-        remote_projs = list_remote_projects()
-        print(remote_projs)
-        assert (owner, title) in remote_projs, \
-            "Expected {owner}/{title} in published project list"
-
-    @property
-    def output_data_tab(self):
-        return self.driver.find_element_by_css_selector("#outputData")
 
 
 class ProjectFileBrowserElements(UiComponent):

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -207,6 +207,10 @@ class AddDatasetElements(UiElement):
         return self.driver.find_element_by_css_selector("button[data-selenium-id = 'ButtonLoader']")
 
     @property
+    def data_tab(self):
+        return self.driver.find_element_by_css_selector("#data")
+
+    @property
     def publish_dataset_button(self):
         return self.driver.find_element_by_css_selector(".BranchMenu__btn--sync--publish")
 
@@ -318,11 +322,18 @@ class PublishProjectElements(UiElement):
     def import_first_cloud_project_button(self):
         return self.driver.find_element_by_css_selector(".RemoteLabbooks__icon--cloud-download")
 
+class CodeElements(UiElement):
+    @property
+    def code_tab(self):
+        return self.driver.find_element_by_css_selector("#code")
 
 class InputDataElements(UiElement):
     @property
     def input_data_tab(self):
         return self.driver.find_element_by_css_selector("#inputData")
 
-
+class OutputDataElements(UiElement):
+    @property
+    def output_data_tab(self):
+        return self.driver.find_element_by_css_selector("#outputData")
 

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -322,17 +322,15 @@ class PublishProjectElements(UiElement):
     def import_first_cloud_project_button(self):
         return self.driver.find_element_by_css_selector(".RemoteLabbooks__icon--cloud-download")
 
-class CodeElements(UiElement):
+class ProjectFileBrowserElements(UiElement):
     @property
     def code_tab(self):
         return self.driver.find_element_by_css_selector("#code")
 
-class InputDataElements(UiElement):
     @property
     def input_data_tab(self):
         return self.driver.find_element_by_css_selector("#inputData")
 
-class OutputDataElements(UiElement):
     @property
     def output_data_tab(self):
         return self.driver.find_element_by_css_selector("#outputData")

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -439,6 +439,10 @@ class ProjectFileBrowserElements(UiComponent):
         return CssElement(self.driver, "#inputData")
 
     @property
+    def container_status_stopped(self):
+        return CssElement(self.driver, ".flex>.Stopped")
+
+    @property
     def link_dataset_button(self):
         return CssElement(self.driver, 'button[data-tooltip="Link Dataset"]')
 

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -42,7 +42,7 @@ class GuideElements(UiElement):
 
     @property
     def helper_button(self):
-        return self.driver.find_element_by_css_selector(".Helper__button--side-view")
+        return self.driver.find_element_by_css_selector(".Helper__button")
 
 
 class AddProjectElements(UiElement):
@@ -209,15 +209,15 @@ class AddDatasetElements(UiElement):
 
     @property
     def dataset_continue_button(self):
-        return self.driver.find_element_by_xpath("//button[contains(text(), 'Continue')]")
+        return self.driver.find_element_by_css_selector(".Btn--last")
 
     @property
     def gigantum_cloud_button(self):
-        return self.driver.find_element_by_xpath("//h6[contains(text(), 'Gigantum Cloud')]")
+        return self.driver.find_element_by_css_selector(".BaseCard")
 
     @property
     def create_dataset_button(self):
-        return self.driver.find_element_by_css_selector(".ButtonLoader")
+        return self.driver.find_element_by_css_selector("button[data-selenium-id = 'ButtonLoader']")
 
     @property
     def publish_dataset_button(self):

--- a/testutils/elements.py
+++ b/testutils/elements.py
@@ -431,6 +431,10 @@ class PublishProjectElements(UiComponent):
 
 class ProjectFileBrowserElements(UiComponent):
     @property
+    def code_tab(self):
+        return CssElement(self.driver, "#code")
+
+    @property
     def input_data_tab(self):
         return CssElement(self.driver, "#inputData")
 

--- a/testutils/testutils.py
+++ b/testutils/testutils.py
@@ -171,5 +171,5 @@ def file_drag_drop(driver):
         example_file.write('Sample Text')
     file_input = driver.execute_script(js_script, drop_target, 0, 0)
     file_input.send_keys(file_path)
-    wait = WebDriverWait(driver, 200)
+    wait = WebDriverWait(driver, 20)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".File__text div span")))

--- a/testutils/testutils.py
+++ b/testutils/testutils.py
@@ -14,6 +14,9 @@ from functools import wraps
 # Library imports
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 
 def TestTags(*taglist):
@@ -93,7 +96,7 @@ def stop_container(driver):
     return driver.find_element_by_css_selector(".flex>.Running").click()
 
 
-def file_drag_drop(driver, project=True):
+def file_drag_drop(driver):
     """ Drag and drop a file into the file browser """
     js_script = """for (var b = arguments[0], k = arguments[1], l = arguments[2], c = b.ownerDocument, m = 0;;) {
             var e = b.getBoundingClientRect(),
@@ -161,22 +164,12 @@ def file_drag_drop(driver, project=True):
         c.documentElement.appendChild(a);
         a.getBoundingClientRect();
         return a;"""
-    if project:
-        drop_target = driver.find_element_by_css_selector(".FileBrowser")
-        logging.info("Adding a file")
-        file_path = '/tmp/sample-upload.txt'
-        with open(file_path, 'w') as example_file:
-            example_file.write('Sample Text')
-        file_input = driver.execute_script(js_script, drop_target, 0, 0)
-        file_input.send_keys(file_path)
-    else:
-        # two different selectors for project file browser vs dataset file browser
-        # below is the selector for dataset file browser
-        drop_target = driver.find_element_by_css_selector(".FileBrowser__empty")
-        logging.info("Adding a file")
-        file_path = '/tmp/sample-upload.txt'
-        with open(file_path, 'w') as example_file:
-            example_file.write('Sample Text')
-        file_input = driver.execute_script(js_script, drop_target, 0, 0)
-        file_input.send_keys(file_path)
-
+    drop_target = driver.find_element_by_css_selector(".FileBrowser")
+    logging.info("Adding file")
+    file_path = '/tmp/sample-upload.txt'
+    with open(file_path, 'w') as example_file:
+        example_file.write('Sample Text')
+    file_input = driver.execute_script(js_script, drop_target, 0, 0)
+    file_input.send_keys(file_path)
+    wait = WebDriverWait(driver, 200)
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".File__text div span")))

--- a/testutils/testutils.py
+++ b/testutils/testutils.py
@@ -163,3 +163,4 @@ def file_drag_drop(driver):
     file_input.send_keys(file_path)
     wait = WebDriverWait(driver, 20)
     wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".File__text div span")))
+    # TODO - refactor and select better CSS selectors

--- a/testutils/testutils.py
+++ b/testutils/testutils.py
@@ -78,7 +78,7 @@ def stop_container(driver):
     return driver.find_element_by_css_selector(".flex>.Running").click()
 
 
-def file_drag_drop(driver):
+def file_drag_drop(driver, project=True):
     """ Drag and drop a file into the file browser """
     js_script = """for (var b = arguments[0], k = arguments[1], l = arguments[2], c = b.ownerDocument, m = 0;;) {
             var e = b.getBoundingClientRect(),
@@ -146,7 +146,7 @@ def file_drag_drop(driver):
         c.documentElement.appendChild(a);
         a.getBoundingClientRect();
         return a;"""
-    try:
+    if project:
         drop_target = driver.find_element_by_css_selector(".FileBrowser")
         logging.info("Adding a file")
         file_path = '/tmp/sample-upload.txt'
@@ -154,7 +154,7 @@ def file_drag_drop(driver):
             example_file.write('Sample Text')
         file_input = driver.execute_script(js_script, drop_target, 0, 0)
         file_input.send_keys(file_path)
-    except:
+    else:
         # two different selectors for project file browser vs dataset file browser
         # below is the selector for dataset file browser
         drop_target = driver.find_element_by_css_selector(".FileBrowser__empty")

--- a/testutils/testutils.py
+++ b/testutils/testutils.py
@@ -76,3 +76,92 @@ def is_container_stopped(driver):
 def stop_container(driver):
     """ Stop container after test is finished """
     return driver.find_element_by_css_selector(".flex>.Running").click()
+
+
+def file_drag_drop(driver):
+    """ Drag and drop a file into the file browser """
+    js_script = """for (var b = arguments[0], k = arguments[1], l = arguments[2], c = b.ownerDocument, m = 0;;) {
+            var e = b.getBoundingClientRect(),
+                g = e.left + (k || e.width / 2),
+                h = e.top + (l || e.height / 2),
+                f = c.elementFromPoint(g, h);
+            if (f && b.contains(f)) break;
+            if (1 < ++m) throw b = Error('Element not interractable'), b.code = 15, b;
+            b.scrollIntoView({
+                behavior: 'instant',
+                block: 'center',
+                inline: 'center'
+            })
+            }
+        var a = c.createElement('INPUT');
+        a.setAttribute('type', 'file');
+        a.setAttribute('style', 'position:fixed;z-index:2147483647;left:0;top:0;');
+        a.onchange = function(evt) {
+            var b = {
+                effectAllowed: 'all',
+                dropEffect: 'none',
+                types: ['Files'],
+                files: this.files,
+                setData: function() {},
+                getData: function() {},
+                clearData: function() {},
+                setDragImage: function() {}
+            };
+            window.DataTransferItemList && (b.items = Object.setPrototypeOf([Object.setPrototypeOf({
+                kind: 'file',
+                type: this.files[0].type,
+                file: this.files[0],
+                getAsFile: function() {
+                    return this.file
+                },
+                getAsEntry: function() {
+                    console.log(evt)
+                    console.log(this, this.file, b)
+                    var isDirectory = this.file.name.indexOf(".") < 0
+                    var isFile = this.file.name.indexOf(".") > -1
+                    return {"file": this.file, "entry": { "fullpath": this.file.name, "file": this.file, 
+                    "name": this.file.name, isDirectory: isDirectory, isFile: isFile}}
+                },
+                getAsString: function(b) {
+                    var a = new FileReader;
+                    a.onload = function(a) {
+                        b(a.target.result)
+                    };
+                    a.readAsText(this.file)
+                }
+            }, DataTransferItem.prototype)], DataTransferItemList.prototype));
+            Object.setPrototypeOf(b, DataTransfer.prototype);
+            ['dragenter', 'dragover', 'drop'].forEach(function(a) {
+                var d = c.createEvent('DragEvent');
+                d.initMouseEvent(a, !0, !0, c.defaultView, 0, 0, 0, g, h, !1, !1, !1, !1, 0, null);
+                Object.setPrototypeOf(d, null);
+                d.dataTransfer = b;
+                console.log(d)
+
+                Object.setPrototypeOf(d, DragEvent.prototype);
+                f.dispatchEvent(d)
+            });
+            a.parentElement.removeChild(a)
+        };
+        c.documentElement.appendChild(a);
+        a.getBoundingClientRect();
+        return a;"""
+    try:
+        drop_target = driver.find_element_by_css_selector(".FileBrowser")
+        logging.info("Adding a file")
+        file_path = '/tmp/sample-upload.txt'
+        with open(file_path, 'w') as example_file:
+            example_file.write('Sample Text')
+        file_input = driver.execute_script(js_script, drop_target, 0, 0)
+        file_input.send_keys(file_path)
+    except:
+        # two different selectors for project file browser vs dataset file browser
+        # below is the selector for dataset file browser
+        drop_target = driver.find_element_by_css_selector(".FileBrowser__empty")
+        logging.info("Adding a file")
+        file_path = '/tmp/sample-upload.txt'
+        with open(file_path, 'w') as example_file:
+            example_file.write('Sample Text')
+        file_input = driver.execute_script(js_script, drop_target, 0, 0)
+        file_input.send_keys(file_path)
+


### PR DESCRIPTION
## Pull Request for Issue #42 

**Description of Changes**
Created a method in testutils that drags and drops a file 
Created a test that drags and drops a file into Code, Input Data, and Output Data in a project
Created a test that drags a drops a file into Data in a dataset

**Exit Criteria**
Tested on visible Chrome and Firefox, does not work for headless Chrome
