### PR TITLE
Quick fix so that test_build_version works for Firefox

### DIFF
--- a/gigantum_tests/test_build_version.py
+++ b/gigantum_tests/test_build_version.py
@@ -4,13 +4,11 @@ import requests
 import sys
 import os
 import json
+import time
 
 # Library imports
 import selenium
 from selenium.webdriver.common.by import By
-
-
-logging.basicConfig(level=logging.INFO)
 
 
 def test_edge_build_versions(driver: selenium.webdriver, *args, **kwargs):
@@ -21,15 +19,22 @@ def test_edge_build_versions(driver: selenium.webdriver, *args, **kwargs):
         driver
     """
     host = f"{os.environ['GIGANTUM_HOST']}/api/ping"
-    # get requests edge build version
+    # Get requests edge build version
+    logging.info("Getting requests edge build version")
     r = requests.get(host)
     if r.status_code != 200:
         logging.error(f"Gigantum is not found at {host}")
         sys.exit(1)
     requests_edge_build_version = json.loads(r.text)
-    # get selenium edge build version
+    # Get selenium edge build version
+    logging.info("Getting selenium edge build version")
     driver.get(host)
-    selenium_edge_build_version = json.loads(driver.find_element_by_css_selector("pre").text)
-    # assert edge build versions match
-    assert requests_edge_build_version == selenium_edge_build_version, \
-        "requests edge build version does not match selenium edge build version"
+    time.sleep(2)
+    if "chrome" == driver.name:
+        selenium_edge_build_version = json.loads(driver.find_element_by_css_selector("pre").text)
+    else:
+        driver.find_element_by_css_selector("#rawdata-tab").click()
+        selenium_edge_build_version = json.loads(driver.find_element_by_css_selector("pre").text)
+
+    assert requests_edge_build_version == selenium_edge_build_version, "requests edge build version does not match " \
+                                                                       "selenium edge build version"

--- a/gigantum_tests/test_build_version.py
+++ b/gigantum_tests/test_build_version.py
@@ -30,11 +30,9 @@ def test_edge_build_versions(driver: selenium.webdriver, *args, **kwargs):
     logging.info("Getting selenium edge build version")
     driver.get(host)
     time.sleep(2)
-    if "chrome" == driver.name:
-        selenium_edge_build_version = json.loads(driver.find_element_by_css_selector("pre").text)
-    else:
-        driver.find_element_by_css_selector("#rawdata-tab").click()
-        selenium_edge_build_version = json.loads(driver.find_element_by_css_selector("pre").text)
+    if driver.name == 'firefox':
+       driver.find_element_by_css_selector("#rawdata-tab").click()
+    selenium_edge_build_version = json.loads(driver.find_element_by_css_selector("pre").text)
 
     assert requests_edge_build_version == selenium_edge_build_version, "requests edge build version does not match " \
                                                                        "selenium edge build version"

--- a/gigantum_tests/test_build_version.py
+++ b/gigantum_tests/test_build_version.py
@@ -34,5 +34,5 @@ def test_edge_build_versions(driver: selenium.webdriver, *args, **kwargs):
        driver.find_element_by_css_selector("#rawdata-tab").click()
     selenium_edge_build_version = json.loads(driver.find_element_by_css_selector("pre").text)
 
-    assert requests_edge_build_version == selenium_edge_build_version, "requests edge build version does not match " \
-                                                                       "selenium edge build version"
+    assert requests_edge_build_version == selenium_edge_build_version, \
+        "requests edge build version does not match selenium edge build version"


### PR DESCRIPTION
## Pull Request for Issue #48

**Description of Changes**
Added in a minor fix for test_build_version so that it works for Firefox driver to include clicking the raw data tab to collect the selenium edge build version.

**Exit Criteria**
Tested on headless & visible Chrome and Firefox
